### PR TITLE
Implemented in-app search with Google Assistant

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -52,6 +52,17 @@
                     android:pathPrefix="/main"
                     android:scheme="https" />
             </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data
+                    android:host="com.mborowiec.antennapod"
+                    android:pathPrefix="/search"
+                    android:scheme="https" />
+            </intent-filter>
         </activity>
         <activity
             android:name=".activity.DownloadAuthenticationActivity"

--- a/app/src/main/java/com/mborowiec/antennapod/activity/MainActivity.java
+++ b/app/src/main/java/com/mborowiec/antennapod/activity/MainActivity.java
@@ -544,8 +544,9 @@ public class MainActivity extends CastEnabledActivity {
     }
 
     /**
-     * Handles the deep link incoming via App Actions and according to the query
-     * either performs an in-app search or opens the relevant feature of the app.
+     * Handles the deep link incoming via App Actions.
+     * Performs an in-app search or opens the relevant feature of the app
+     * depending on the query.
      *
      * @param uri incoming deep link
      */

--- a/app/src/main/java/com/mborowiec/antennapod/activity/MainActivity.java
+++ b/app/src/main/java/com/mborowiec/antennapod/activity/MainActivity.java
@@ -36,12 +36,14 @@ import com.mborowiec.antennapod.core.util.StorageUtils;
 import com.mborowiec.antennapod.core.util.ThemeUtils;
 import com.mborowiec.antennapod.core.util.download.AutoUpdateManager;
 import com.mborowiec.antennapod.dialog.RatingDialog;
+import com.mborowiec.antennapod.discovery.CombinedSearcher;
 import com.mborowiec.antennapod.fragment.AddFeedFragment;
 import com.mborowiec.antennapod.fragment.AudioPlayerFragment;
 import com.mborowiec.antennapod.fragment.DownloadsFragment;
 import com.mborowiec.antennapod.fragment.EpisodesFragment;
 import com.mborowiec.antennapod.fragment.FeedItemlistFragment;
 import com.mborowiec.antennapod.fragment.NavDrawerFragment;
+import com.mborowiec.antennapod.fragment.OnlineSearchFragment;
 import com.mborowiec.antennapod.fragment.PlaybackHistoryFragment;
 import com.mborowiec.antennapod.fragment.QueueFragment;
 import com.mborowiec.antennapod.fragment.SubscriptionFragment;
@@ -542,40 +544,54 @@ public class MainActivity extends CastEnabledActivity {
     }
 
     /**
-     * Handles the incoming deep link and loads the relevant fragment.
-     * By default, opens the "Add Podcast" feature.
+     * Handles the deep link incoming via App Actions and according to the query
+     * either performs an in-app search or opens the relevant feature of the app.
      *
      * @param uri incoming deep link
      */
     private void handleDeeplink(Uri uri) {
-        if (uri == null) {
+        if (uri == null || uri.getPath() == null) {
            return;
         }
 
-        String feature = uri.getQueryParameter("featureName");
-        if(feature == null) {
-            return;
-        }
+        switch (uri.getPath()) {
+            case "/search":
+                String query = uri.getQueryParameter("query");
+                if (query == null) {
+                    return;
+                }
 
-        feature = feature.toLowerCase();
-        switch (feature) {
-            case "downloads":
-                loadFragment(DownloadsFragment.TAG, null);
+                this.loadChildFragment(OnlineSearchFragment.newInstance(CombinedSearcher.class, query));
                 break;
-            case "history":
-                 loadFragment(PlaybackHistoryFragment.TAG, null);
-                 break;
-            case "episodes":
-                loadFragment(EpisodesFragment.TAG, null);
+
+            case "/main":
+                String feature = uri.getQueryParameter("featureName");
+                if (feature == null) {
+                    return;
+                }
+
+                feature = feature.toLowerCase();
+                switch (feature) {
+                    case "downloads":
+                        loadFragment(DownloadsFragment.TAG, null);
+                        break;
+                    case "history":
+                        loadFragment(PlaybackHistoryFragment.TAG, null);
+                        break;
+                    case "episodes":
+                        loadFragment(EpisodesFragment.TAG, null);
+                        break;
+                    case "queue":
+                        loadFragment(QueueFragment.TAG, null);
+                        break;
+                    case "subscriptions":
+                        loadFragment(SubscriptionFragment.TAG, null);
+                        break;
+                    default:
+                        loadFragment(AddFeedFragment.TAG, null);
+                        break;
+                }
                 break;
-            case "queue":
-                loadFragment(QueueFragment.TAG, null);
-                break;
-            case "subscriptions":
-                loadFragment(SubscriptionFragment.TAG, null);
-                break;
-            default:
-                loadFragment(AddFeedFragment.TAG, null);
         }
     }
 }

--- a/app/src/main/res/xml/actions.xml
+++ b/app/src/main/res/xml/actions.xml
@@ -15,6 +15,15 @@ https://developers.google.com/assistant/app/overview -->
         </parameter>
     </action>
 
+    <action intentName="actions.intent.GET_THING">
+        <!-- TODO: Change URL to use the right path with the original package name -->
+        <fulfillment urlTemplate="https://com.mborowiec.antennapod/search{?query}">
+            <parameter-mapping
+                intentParameter="thing.name"
+                urlParameter="query"/>
+        </fulfillment>
+    </action>
+
     <entity-set entitySetId="featureEntitySet">
         <entity identifier="QUEUE" name="Queue" />
         <entity identifier="EPISODES" name="Episodes" />


### PR DESCRIPTION
This pull request implements the “**Get thing**” built-in intent (https://developers.google.com/assistant/app/reference/built-in-intents/common/get-thing) to enable users to use the in-app search of AntennaPod directly from the Google Assistant with queries of type “**_Search for BBC on AntennaPod_**”.

It can be tested with the App Actions test tool plugin in Android Studio (https://developers.google.com/assistant/app/test-tool). App Actions are supported on Android 5 (API level 21) and higher, and can only be tested with a physical device.